### PR TITLE
Fix files finding error if the glob result of excludes containing directory.

### DIFF
--- a/news/bugfix.17.md
+++ b/news/bugfix.17.md
@@ -1,0 +1,1 @@
+Fix files finding error if the glob result of excludes containing directory.

--- a/pdm/pep517/base.py
+++ b/pdm/pep517/base.py
@@ -51,9 +51,10 @@ class BuildError(RuntimeError):
     pass
 
 
-def _match_path(path: str, pattern: str) -> bool:
-    return normalize_path(os.path.abspath(path)) == normalize_path(
-        os.path.abspath(pattern)
+def is_same_or_descendant_path(target: str, path: str) -> bool:
+    """Check target is same or descendant with path"""
+    return normalize_path(os.path.abspath(target)).startswith(
+        normalize_path(os.path.abspath(path))
     )
 
 
@@ -167,7 +168,7 @@ class Builder:
 
         includes, excludes = _merge_globs(include_globs, excludes_globs)
         for path in find_froms:
-            if any(_match_path(path, item) for item in dont_find_froms):
+            if any(is_same_or_descendant_path(path, item) for item in dont_find_froms):
                 continue
             path_base = os.path.dirname(path)
             if not path_base or path_base == ".":
@@ -178,7 +179,7 @@ class Builder:
 
                 for filename in filenames:
                     if filename.endswith(".pyc") or any(
-                        _match_path(os.path.join(root, filename), item)
+                        is_same_or_descendant_path(os.path.join(root, filename), item)
                         for item in excludes
                     ):
                         continue

--- a/tests/test_file_finder.py
+++ b/tests/test_file_finder.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
+import pytest
+
 from pdm.pep517 import utils
-from pdm.pep517.base import Builder
+from pdm.pep517.base import Builder, is_same_or_descendant_path
 from tests import FIXTURES
 
 
@@ -22,3 +24,17 @@ def test_auto_include_tests_for_sdist():
         path = Path(file)
         assert path in sdist_files
         assert path not in wheel_files
+
+
+@pytest.mark.parametrize(
+    "target,path,expect",
+    [
+        ("a/b", "a", True),
+        ("a/b/c", "a/b/c", True),
+        ("b/c", "a", False),
+        ("a", "a/b", False),
+        ("a", "b/c", False),
+    ],
+)
+def test_is_same_or_descendant_path(target, path, expect):
+    assert is_same_or_descendant_path(target, path) == expect


### PR DESCRIPTION
Recently I used `pdm build` to build the source distribution file and found out it contains some un-required files such as cache files generated by **mypy**. So I used `excludes = ["**/.mypy_cache"]` from `[tool.pdm]` sections in `pyproject.toml` file. But it doesn't work at all.

I did some digging about the root cause of this problem. The `_find_files_iter` method uses exclude glob patterns to generate directories and files which need to be excluded from the distribution building. But the `_match_path` doesn't consider the scenario of `pattern` as a directory.