### PR TITLE
Rename the dynamic verison fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Then in `[tool.pdm]` table, specify how to get the version info. There are two w
 
 ```toml
 [tool.pdm]
-version = {from = "mypackage/__init__.py"}
+version = {source = "file", path = "mypackage/__init__.py"}
 ```
 
 In this way, the file MUST contain a line like:
@@ -78,7 +78,7 @@ __version__ = "0.1.0" # Single quotes and double quotes are both OK, comments ar
 
 ```toml
 [tool.pdm]
-version = {use_scm = true}
+version = {source = "scm"}
 ```
 
 When building from a source tree where SCM is not available, you can use the env var `PDM_PEP517_SCM_VERSION` to pretend the version is set.

--- a/news/95.feature.md
+++ b/news/95.feature.md
@@ -1,0 +1,1 @@
+The dynamic version table fields are renamed: `{from = ...}` to `{source = "file", path = ...}` and `{use_scm = true}` to `{source = "scm"}`.

--- a/pdm/pep517/version.py
+++ b/pdm/pep517/version.py
@@ -1,0 +1,81 @@
+import os
+import re
+import warnings
+from typing import Any, Dict
+
+from pdm.pep517.exceptions import MetadataError, PDMWarning
+from pdm.pep517.scm import get_version_from_scm
+
+
+class DynamicVersion:
+    """Dynamic version implementation.
+
+    Currently supports `file` and `scm` sources.
+    """
+
+    _valid_args = {"file": ["path"], "scm": ["write_to", "write_to_template"]}
+
+    def __init__(self, source: str, **kwargs: Any) -> None:
+        self.source = source
+        self.kwargs = kwargs
+
+    @classmethod
+    def from_toml(cls, toml: Dict[str, Any]) -> "DynamicVersion":
+        """Create a DynamicVersion from a TOML dictionary."""
+        options = toml.copy()
+        if "from" in options:
+            source = "file"
+            path = options["from"]
+            warnings.warn(
+                "DEPRECATED: `version = {from = ...}` is replaced by "
+                '`version = {source = "file", path = ...}`',
+                PDMWarning,
+                stacklevel=2,
+            )
+            return cls(source, path=path)
+
+        if "use_scm" in options:
+            source = "scm"
+            warnings.warn(
+                "DEPRECATED: `version = {use_scm = true}` is replaced by "
+                '`version = {source = "scm"}`',
+                PDMWarning,
+                stacklevel=2,
+            )
+            options.pop("use_scm")
+        else:
+            source = options.pop("source", None)
+
+        if source not in cls._valid_args:
+            raise MetadataError(
+                "version",
+                f"Invalid source for dynamic version: {source}, "
+                f"allowed: {', '.join(cls._valid_args)}",
+            )
+        allowed_args = cls._valid_args[source]
+        unrecognized_args = set(options) - set(allowed_args)
+        if unrecognized_args:
+            raise MetadataError(
+                "version",
+                f"Unrecognized arguments for dynamic version: {unrecognized_args}, "
+                f"allowed: {', '.join(allowed_args)}",
+            )
+        return cls(source, **options)
+
+    def evaluate_in_project(self, root: str) -> str:
+        """Evaluate the dynamic version."""
+        if self.source == "file":
+            version_source = os.path.join(root, self.kwargs["path"])
+            with open(version_source, encoding="utf-8") as fp:
+                match = re.search(
+                    r"^__version__\s*=\s*[\"'](.+?)[\"']\s*(?:#.*)?$", fp.read(), re.M
+                )
+                if not match:
+                    raise MetadataError(
+                        "version",
+                        f"Can't find version in file {version_source}, "
+                        "it should appear as `__version__ = 'a.b.c'`.",
+                    )
+                return match.group(1)
+        else:
+            return get_version_from_scm(root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ homepage = "https://pdm.fming.dev"
 repository = "https://github.com/frostming/pdm-pep517"
 
 [tool.pdm]
-version = {from = "pdm/pep517/__init__.py"}
+version = {source = "file", path = "pdm/pep517/__init__.py"}
 includes = ["pdm"]
 source-includes = ["tests"]
 

--- a/tests/fixtures/projects/demo-cextension-in-src/pyproject.toml
+++ b/tests/fixtures/projects/demo-cextension-in-src/pyproject.toml
@@ -16,7 +16,7 @@ name = "demo-package"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "src/my_package/__init__.py" }
+version = {source = "file", path = "src/my_package/__init__.py" }
 source-includes = ["**/*.c"]
 build = "build.py"
 

--- a/tests/fixtures/projects/demo-cextension/pyproject.toml
+++ b/tests/fixtures/projects/demo-cextension/pyproject.toml
@@ -16,7 +16,7 @@ name = "demo-package"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }
 source-includes = ["**/*.c"]
 build = "build.py"
 

--- a/tests/fixtures/projects/demo-explicit-package-dir/pyproject.toml
+++ b/tests/fixtures/projects/demo-explicit-package-dir/pyproject.toml
@@ -16,5 +16,5 @@ name = "demo-package"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "foo/my_package/__init__.py" }
+version = {source = "file", path = "foo/my_package/__init__.py" }
 package-dir = "foo"

--- a/tests/fixtures/projects/demo-module/pyproject.toml
+++ b/tests/fixtures/projects/demo-module/pyproject.toml
@@ -17,4 +17,4 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "foo_module.py" }
+version = {source = "file", path = "foo_module.py" }

--- a/tests/fixtures/projects/demo-no-license/pyproject.toml
+++ b/tests/fixtures/projects/demo-no-license/pyproject.toml
@@ -17,4 +17,4 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "src/foo_module.py" }
+version = {source = "file", path = "src/foo_module.py" }

--- a/tests/fixtures/projects/demo-package-include-error/pyproject.toml
+++ b/tests/fixtures/projects/demo-package-include-error/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }
 includes = [
     "my_package/",
     "single_module.py",

--- a/tests/fixtures/projects/demo-package-include-old/pyproject.toml
+++ b/tests/fixtures/projects/demo-package-include-old/pyproject.toml
@@ -25,4 +25,4 @@ excludes = [
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }

--- a/tests/fixtures/projects/demo-package-include/pyproject.toml
+++ b/tests/fixtures/projects/demo-package-include/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }
 includes = [
     "my_package/",
     "requirements.txt",

--- a/tests/fixtures/projects/demo-package-with-deep-path/pyproject.toml
+++ b/tests/fixtures/projects/demo-package-with-deep-path/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }
 source-includes = ["my_package/**/*.json"]
 
 [[tool.pdm.source]]

--- a/tests/fixtures/projects/demo-package-with-tests/pyproject.toml
+++ b/tests/fixtures/projects/demo-package-with-tests/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }
 
 [[tool.pdm.source]]
 url = "https://test.pypi.org/simple"

--- a/tests/fixtures/projects/demo-package/pyproject.toml
+++ b/tests/fixtures/projects/demo-package/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }
 source-includes = ["data_out.json"]
 editable-backend = "editables"
 

--- a/tests/fixtures/projects/demo-pep420-package/pyproject.toml
+++ b/tests/fixtures/projects/demo-pep420-package/pyproject.toml
@@ -16,6 +16,6 @@ name = "demo-package"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "foo/my_package/__init__.py" }
+version = {source = "file", path = "foo/my_package/__init__.py" }
 includes = ["foo/"]
 editable-backend = "editables"

--- a/tests/fixtures/projects/demo-purelib-with-build/pyproject.toml
+++ b/tests/fixtures/projects/demo-purelib-with-build/pyproject.toml
@@ -16,7 +16,7 @@ name = "demo-package"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "my_package/__init__.py" }
+version = {source = "file", path = "my_package/__init__.py" }
 source-includes = ["**/*.c"]
 build = "build.py"
 is-purelib = true

--- a/tests/fixtures/projects/demo-src-package-include/pyproject.toml
+++ b/tests/fixtures/projects/demo-src-package-include/pyproject.toml
@@ -16,7 +16,7 @@ name = "demo-package"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "sub/my_package/__init__.py" }
+version = {source = "file", path = "sub/my_package/__init__.py" }
 includes = ["sub", "data_out.json"]
 package-dir = "sub"
 editable-backend = "editables"

--- a/tests/fixtures/projects/demo-src-package/pyproject.toml
+++ b/tests/fixtures/projects/demo-src-package/pyproject.toml
@@ -16,4 +16,4 @@ name = "demo-package"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "src/my_package/__init__.py" }
+version = {source = "file", path = "src/my_package/__init__.py" }

--- a/tests/fixtures/projects/demo-src-pymodule/pyproject.toml
+++ b/tests/fixtures/projects/demo-src-pymodule/pyproject.toml
@@ -17,4 +17,4 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { from = "src/foo_module.py" }
+version = {source = "file", path = "src/foo_module.py" }

--- a/tests/fixtures/projects/demo-using-scm/pyproject.toml
+++ b/tests/fixtures/projects/demo-using-scm/pyproject.toml
@@ -17,4 +17,4 @@ readme = "README.md"
 [project.optional-dependencies]
 
 [tool.pdm]
-version = { use_scm = true }
+version = {source = "scm" }


### PR DESCRIPTION
New version table:

```toml
[tool.pdm.version]
source = "file"
path = "mypackage/__version__.py"
```

OR:
```toml
[tool.pdm.version]
source = "scm"
```

The old names are deprecated at the same time.