### PR TITLE
tests: Configure git for scm tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ def project_with_scm(tmp_path):
     shutil.copytree(project, tmp_path / project.name)
     with utils.cd(tmp_path / project.name):
         subprocess.check_call(["git", "init"])
+        subprocess.check_call(["git", "config", "user.email", "you@any.com"])
+        subprocess.check_call(["git", "config", "user.name", "Name"])
         subprocess.check_call(["git", "add", "."])
         subprocess.check_call(["git", "commit", "-m", "initial commit"])
         subprocess.check_call(["git", "tag", "-a", "0.1.0", "-m", "version 0.1.0"])


### PR DESCRIPTION
Some of the tests fail on systems that haven't configured git. For example, some downstreams run tests out of a git tree and may not have configured git.

Fixes: https://github.com/pdm-project/pdm-pep517/issues/125